### PR TITLE
Api pagination

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -162,11 +162,14 @@ export default function Page() {
   }
 
   const fetchAnimals = (): void => {
-    // setLoading(true)
-    client.animal.search()
-        .then(response => {
-          setListings(response.data.animals);
-        })
+    client.animal.search({
+      page: currentListingsPage,
+    }).then(response => {
+        setListings((previousValue: Animal[]) => {
+          const allListings: Animal[] = [...previousValue, ...response.data.animals];
+          return allListings.filter((item, index) => allListings.indexOf(item) === index);
+        });
+      })
     setLoading(false);
   }
 

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -181,11 +181,11 @@ export default function Page() {
     if(!loading && listings.length) {
       if(listing.photos.length) {
         return (
-            <img src={listing.photos[currentImageIndex]?.medium} alt={listing.breed}/>
+            <img src={listing.photos[currentImageIndex]?.medium} alt={listing.name}/>
         )
       } else {
         return (
-            <img src="" alt={listing.breed}/>
+            <img src="" alt={listing.name}/>
         )
       }
     }

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -145,8 +145,11 @@ export default function Page() {
       }, 500);
 
   const handleButtonPress = (dir: String) => {
-    const currentListing: Animal = listings[currentListingIndex];
-    const currentImagesLength = currentListing.photos.length - 1;
+    const currentListing: Animal | undefined = listings[currentListingIndex];
+    let currentImagesLength: number;
+    if(currentListing) {
+      currentImagesLength = currentListing.photos.length - 1;
+    }
     setCurrentImageIndex(previousValue => {
       if(dir ===  "next" && previousValue < currentImagesLength) {
         return previousValue + 1;

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -176,7 +176,7 @@ export default function Page() {
   useEffect(() => {
     setLoading(true);
     fetchAnimals();
-  }, []);
+  }, [currentListingsPage]);
 
   useEffect(() => {
     const handleScroll: EventHandler<any> = (event) => {

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -4,7 +4,6 @@ import React, {EventHandler, useEffect, useState} from "react";
 import {debounce} from "lodash";
 import client from "@/api/client";
 
-const pfBaseUrl = "http://localhost:3000/";
 
 type Animal = {
   "id": number,
@@ -87,7 +86,6 @@ export default function Page() {
   const [listings, setListings] = useState([])
 
   const [currentListingIndex, setCurrentListingIndex] = useState(0);
-  const [scrolling, setScrolling] = useState("");
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [loading, setLoading] = useState(false);
 
@@ -123,7 +121,6 @@ export default function Page() {
             return previousValue;
           })
         }
-        setScrolling("");
         setCurrentImageIndex(0);
       }, 500);
 
@@ -157,41 +154,6 @@ export default function Page() {
 
   useEffect(() => {
     const handleScroll: EventHandler<any> = (event) => {
-      let listing = document.querySelector(".listing");
-      let nextListing = document.querySelector(".listing--next");
-      let prevListing = document.querySelector(".listing--prev");
-      if(event.wheelDeltaY < 0) {
-        setScrolling("down");
-        setCurrentListingIndex(previousValue => {
-          if(previousValue < listings.length - 1) {
-            if(listing) {
-              listing.className = "listing scrolling--down";
-            }
-
-            if(nextListing) {
-              nextListing.className = "listing--next scrolling--down"
-            }
-          }
-          return previousValue;
-        })
-      }
-
-      if(event.wheelDeltaY > 0) {
-        setScrolling("up");
-        setCurrentListingIndex(previousValue => {
-          if(previousValue > 0) {
-            if(listing) {
-              listing.className = "listing scrolling--up";
-            }
-
-            if(prevListing) {
-              prevListing.className = "listing--prev scrolling--up"
-            }
-          }
-          return previousValue;
-        })
-      }
-
       debouncedScroll(event);
     };
 

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -83,7 +83,7 @@ type Animal = {
 }
 
 export default function Page() {
-  const [listings, setListings] = useState([])
+  const [listings, setListings] = useState<Animal[]>([])
 
   const [currentListingIndex, setCurrentListingIndex] = useState(0);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -97,10 +97,10 @@ export default function Page() {
           return ++prevPage;
         })
         nextListing();
+        return prevIndex;
       } else {
         return ++prevIndex;
       }
-      return prevIndex;
     })
   }
 
@@ -122,7 +122,7 @@ export default function Page() {
       })
     }
     scrollToListing();
-  }, [currentListingIndex, listings]);
+  }, [currentListingIndex, listings.length]);
 
   const scrollToListing = () => {
     const nextListing: Animal = listings[currentListingIndex];

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -2,8 +2,7 @@
 import "./index.css"
 import React, {EventHandler, useEffect, useState} from "react";
 import {debounce} from "lodash";
-import axios from "axios";
-import client from "@/api/client.ts";
+import client from "@/api/client";
 
 const pfBaseUrl = "http://localhost:3000/";
 

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -114,37 +114,32 @@ export default function Page() {
 
   }
 
+  useEffect(() => {
+    if(currentListingIndex === 0 && !listings.length) return;
+    if(currentListingIndex === listings.length - 1) {
+      setCurrentListingsPage((prevPage: number) => {
+        return ++prevPage;
+      })
+    }
+    scrollToListing();
+  }, [currentListingIndex, listings]);
+
+  const scrollToListing = () => {
+    const nextListing: Animal = listings[currentListingIndex];
+    const nextListingID: number = nextListing.id;
+    const element = document.getElementById("" + nextListingID);
+    if(element) {
+      element.scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
+    }
+  }
+
   const debouncedScroll =
       debounce((event) => {
         if(event.wheelDeltaY < 0) {
-          setCurrentListingIndex(previousValue => {
-            if(previousValue < listings.length - 1) {
-              const nextValue = previousValue + 1;
-              const nextListing: Animal = listings[nextValue];
-              const nextListingID = nextListing.id;
-              const element = document.getElementById("" + nextListingID);
-              if(element) {
-                element.scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
-              }
-              return nextValue;
-            }
-            return previousValue;
-          })
+          nextListing();
         }
         if(event.wheelDeltaY > 0){
-          setCurrentListingIndex(previousValue => {
-            if(previousValue > 0) {
-              const newValue = previousValue - 1;
-              const prevListing: Animal = listings[newValue];
-              const prevListingID = prevListing.id;
-              const element = document.getElementById("" + prevListingID);
-              if(element) {
-                element.scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
-              }
-              return newValue;
-            }
-            return previousValue;
-          })
+          prevListing();
         }
         setCurrentImageIndex(0);
       }, 500);

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -88,6 +88,31 @@ export default function Page() {
   const [currentListingIndex, setCurrentListingIndex] = useState(0);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [currentListingsPage, setCurrentListingsPage] = useState(1);
+
+  function nextListing() {
+    setCurrentListingIndex((prevIndex) => {
+      if(prevIndex === listings.length - 1) {
+        setCurrentListingsPage((prevPage: number) => {
+          return ++prevPage;
+        })
+        nextListing();
+      } else {
+        return ++prevIndex;
+      }
+      return prevIndex;
+    })
+  }
+
+  function prevListing() {
+    setCurrentListingIndex((prevIndex) => {
+      if(prevIndex > 0) {
+        return --prevIndex;
+      }
+      return prevIndex;
+    })
+
+  }
 
   const debouncedScroll =
       debounce((event) => {

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -195,15 +195,7 @@ export default function Page() {
     listing: Animal
   }
 
-  function ListingPhoto({ current, listing } : PhotoProps) {
-    let listingIndex = 0;
-    if(current === 'current') {
-      listingIndex = currentListingIndex
-    } else if(current === 'next') {
-      listingIndex = currentListingIndex + 1;
-    } else if(current === 'prev') {
-      listingIndex = currentListingIndex - 1;
-    }
+  function ListingPhoto({ listing } : PhotoProps) {
     if(!loading && listings.length) {
       if(listing.photos.length) {
         return (

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -262,7 +262,7 @@ export default function Page() {
   function ImageButtons() {
     if(loading) return;
     return (
-      <div className={scrolling ? "buttons buttons--scrolling" : "buttons"}>
+      <div>
         <PrevButton></PrevButton>
         <NextButton></NextButton>
       </div>


### PR DESCRIPTION
Basic pagination: When user scrolls down to last listing, increment page. There's a useEffect hook that will invoke fetchAnimals when page state is updated. After the page is incremented and more listings are fetched, the nextListing function is recursive and invokes itself. This will then increment the currentListingsIndex. There is then another useEffect hook that has the index as a dependency. When the index is updated, the scrollToListing function is invoked that will scroll to the listing with the matching id. 

Issues: 
- Pagination breaks due to duplicate iteration key attributes once the next page is fetched. This is due to a couple reasons:
  - No addition parameters or filters have been set, which is especially a problem with the lack of location and distance since nationwide listings are being fetched. The listings are so frequently published that once you scroll through the 20 listings, it's possible that another 20 have already been published thus making the original 20 fetched the next page fetched. 

While this may be mostly mitigated by setting more filters like like location, distance, animal type, age, breed, etc, the more complete fix is to get the timestamp of the first item in the fetched results (since the default sort is date desc), then every subsequent fetch uses that timestamp as the after parameter. This is the best solution for the current implementation.