### PR TITLE
Api after date

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -175,6 +175,9 @@ export default function Page() {
           return allListings.filter((item, index) => allListings.indexOf(item) === index);
         });
       })
+        .catch(err => {
+          console.log(err);
+        })
     setLoading(false);
   }
 

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -89,6 +89,7 @@ export default function Page() {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [loading, setLoading] = useState(false);
   const [currentListingsPage, setCurrentListingsPage] = useState(1);
+  const [beforeTimestamp, setBeforeTimestamp] = useState(new Date().toISOString());
 
   function nextListing() {
     setCurrentListingIndex((prevIndex) => {

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -268,13 +268,17 @@ export default function Page() {
   }
 
   function ImageButtons() {
-    if(loading) return;
-    return (
-      <div>
-        <PrevButton></PrevButton>
-        <NextButton></NextButton>
-      </div>
-    )
+    if(!loading && listings.length && listings[currentListingIndex]) {
+      if(listings[currentListingIndex].photos.length) {
+        return (
+            <div>
+              <PrevButton></PrevButton>
+              <NextButton></NextButton>
+            </div>
+        )
+      }
+    }
+    return;
   }
 
   return (

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -117,7 +117,7 @@ export default function Page() {
 
   useEffect(() => {
     if(currentListingIndex === 0 && !listings.length) return;
-    if(currentListingIndex === listings.length - 1) {
+    if(currentListingIndex === listings.length - 2) {
       setCurrentListingsPage((prevPage: number) => {
         return ++prevPage;
       })

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -165,7 +165,11 @@ export default function Page() {
   const fetchAnimals = (): void => {
     client.animal.search({
       page: currentListingsPage,
+      before: beforeTimestamp
     }).then(response => {
+        if(response.data.pagination.current_page === '1') {
+          setBeforeTimestamp(response.data.animals[0].published_at);
+        }
         setListings((previousValue: Animal[]) => {
           const allListings: Animal[] = [...previousValue, ...response.data.animals];
           return allListings.filter((item, index) => allListings.indexOf(item) === index);

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -196,7 +196,7 @@ export default function Page() {
     return () => {
       window.removeEventListener('mousewheel', handleScroll);
     };
-  }, [listings])
+  }, [])
 
   type PhotoProps = {
     current: string,

--- a/workplans/0001-api-after-parameter.md
+++ b/workplans/0001-api-after-parameter.md
@@ -1,0 +1,39 @@
+API after date parameter
+
+Currently, there is an issue with the pagination. As is, once you get to the end of the listings array, the page state will increment. A useEffect hook will then fetchAnimals because the page was updated and use the new page state for the page parameter. However, because we're grabbing nationwide listings without any other filters, by the time the initial 20 is scrolled through, it's possible that another 20 have been published already thus making the initial 20 we fetched on the first page on the second page now. This causes a duplicate iteration key error which also breaks the scrolling. 
+
+To fix this, create a new state variable for a timestamp [afterTimestamp]. Then on initial fetch, set afterTimestamp equal to the published_at timestamp from the first listing in the results. The fetch will always use this as an anchor. Now newer listings won't be fetched, causing any listings that were already fetched to shift and thus re-fetched. 
+
+pseudocode:
+
+create a new state variable for the timestamp
+~~~
+const [afterTimestamp, setAfterTimestamp] = useState("")
+~~~
+
+
+after initial mount and fetch, once listings have been set, create another useEffect hook with listings as a dependency. There are also conditions so that the hook code will only run on the first fetch
+~~~
+useEffect(() => {
+    if(listings.length && currentListingIndex === 0 && currentPageIndex === 0) {
+        setAfterTimestamp(listings[0].publishedAt);
+    }
+}, [listings]);
+~~~
+
+
+then modify the fetch to use the after timestamp for the parameter
+~~~
+const fetchAnimals = (): void => {
+    client.animal.search({
+        page: currentListingsPage,
+        after: afterTimestamp
+    }).then(response => {
+        setListings((previousValue: Animal[]) => {
+            const allListings: Animal[] = [...previousValue, ...response.data.animals];
+            return allListings.filter((item, index) => allListings.indexOf(item) === index);
+        });
+    })
+    setLoading(false);
+}
+~~~


### PR DESCRIPTION
A new beforeTimestamp state var was created to hold the data of the first retrieved listing's publish date. This was to ensure that no duplicate listings were retrieved if new listings were published causing already fetched listings to be shifted down.

beforeTimestamp has initial value of new Date.now(). Then after only the first fetch, the timestamp is updated to be the value of the first listing's published_at timestamp.

<ImageButtons> component was also fixed to fix bugs with the conditional rendering.